### PR TITLE
Initial plugin build with automatic registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ The DevContainer is configured to automatically load these environment variables
 
 The plugin uses the following settings:
 
-- `url`: Base URL for the service (default: "http://192.168.42.102:54321", can be set via env var)
-- `anon_key`: Supabase anonymous key for initial authentication (default: empty, can be set via env var)
-- `registration_token`: Token used for printer registration (default: empty, can be set via env var)
+- `url`: Base URL for the service (default: "", can be provided via $ADDITV_URL)
+- `anon_key`: Supabase anonymous key for initial authentication (default: empty, can be provided via $ADDITV_ANON_KEY)
+- `registration_token`: Token used for printer registration (default: empty, can be provided via $ADDITV_REGISTRATION_TOKEN)
 - `service_user`: Service user identifier for the printer (set automatically during registration)
 - `printer_id`: Unique identifier for the printer (set automatically during registration)
 - `access_key`: Access token (set automatically during registration)


### PR DESCRIPTION
Need to provide env vars for URL, Anon Key and Registration Token for auto registration to occur. 

Printer will then create a printers record and auth.user for itself.   The printer will only have access to and be able to write to data with its own printer_id in the printers or printer_events (and future) tables, so leaking of one of these refresh tokens will only expose a single printer's data.  